### PR TITLE
Replace GTK Widgets with Custom Widgets to Help with Upgrade to GTK4

### DIFF
--- a/examples/gtk.rs
+++ b/examples/gtk.rs
@@ -3,40 +3,37 @@ use gtk4::prelude::*;
 #[cfg(target_os = "linux")]
 use keyboard_types::{Code, Modifiers};
 #[cfg(target_os = "linux")]
-use muda::{accelerator::Accelerator, MenuEvent};
+use muda::{accelerator::Accelerator, ContextMenu, MenuEvent};
 
 #[cfg(target_os = "linux")]
 fn main() {
-    // Create a new application
     let application = gtk4::Application::builder()
-        .application_id("com.github.gtk4-rs.examples.menubar")
+        .application_id("com.github.muda.example.gtk")
         .build();
-    application.connect_startup(on_startup);
-    application.connect_activate(on_activate);
+
+    application.connect_startup(|_| {
+        MenuEvent::set_event_handler(Some(|event| {
+            println!("{event:?}");
+        }))
+    });
+
+    application.connect_activate(move |application| {
+        let window = gtk4::ApplicationWindow::builder()
+            .application(application)
+            .title("GTK Menubar Example")
+            .default_width(350)
+            .default_height(350)
+            .show_menubar(true)
+            .build();
+
+            setup_ui(&window);
+    });
+
     application.run();
 }
 
 #[cfg(target_os = "linux")]
-fn on_startup(_: &gtk4::Application) {
-    MenuEvent::set_event_handler(Some(|event| {
-        println!("{event:?}");
-    }));
-}
-
-#[cfg(target_os = "linux")]
-fn on_activate(application: &gtk4::Application) {
-    use muda::ContextMenu;
-
-    let window = gtk4::ApplicationWindow::builder()
-        .application(application)
-        .title("Menubar Example")
-        .default_width(350)
-        .default_height(350)
-        .show_menubar(true)
-        .build();
-
-    window.present();
-
+fn setup_ui(window: &gtk4::ApplicationWindow) {
     let about_menu_item = muda::MenuItem::new("About", true, None);
 
     let check = muda::CheckMenuItem::new(
@@ -67,7 +64,7 @@ fn on_activate(application: &gtk4::Application) {
     menubar.append(&file_menu).unwrap();
 
     let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
-    menubar.init_for_gtk_window(&window, Some(&vbox)).unwrap();
+    menubar.init_for_gtk_window(window, Some(&vbox)).unwrap();
 
     let btn = gtk4::Button::with_label("ASdasd");
     let w = window.clone();
@@ -75,13 +72,17 @@ fn on_activate(application: &gtk4::Application) {
     btn.connect_clicked(move |_| {
         file_menu.show_context_menu_for_gtk_window(w.dynamic_cast_ref().unwrap(), None);
     });
+
     vbox.append(&btn);
 
     window.set_child(Some(&vbox));
+    window.present();
 }
 
 #[cfg(not(target_os = "linux"))]
-fn main() {}
+fn main() {
+    eprintln!("This example is only available on Linux");
+}
 
 fn load_icon(path: &std::path::Path) -> muda::Icon {
     let (icon_rgba, icon_width, icon_height) = {

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "linux")]
 use gtk4::{
-    gio::{self, prelude::*, File, FileIcon},
+    gio::{self, prelude::*, File, FileIcon, ThemedIcon},
     prelude::*,
 };
 
@@ -28,68 +28,111 @@ fn main() {
         ))));
 
         let menu = {
-            let icon_section = gio::Menu::new();
-            let icon_with_label_menu_item =
-                gio::MenuItem::new(Some("Icon With Label"), Some("muda.icon"));
+            let file_menu = {
+                let icon_section = gio::Menu::new();
+                let icon_with_label_menu_item =
+                    gio::MenuItem::new(Some("Icon With Label"), Some("muda.icon"));
 
-            icon_with_label_menu_item.set_icon(&icon);
+                icon_with_label_menu_item.set_icon(&icon);
 
-            icon_section.append_item(&icon_with_label_menu_item);
+                icon_section.append_item(&icon_with_label_menu_item);
 
-            let submenu_item = gio::MenuItem::new(Some("Icon Submenu"), None);
+                let submenu_item = gio::MenuItem::new(Some("Icon Submenu"), None);
 
-            let icon_submenu = gio::Menu::new();
-            let icon_menu_item =
-                gio::MenuItem::new(Some("Icon Accelerator"), Some("muda.icon-accel"));
+                let icon_submenu = gio::Menu::new();
+                let icon_menu_item =
+                    gio::MenuItem::new(Some("Icon Accelerator"), Some("muda.icon-accel"));
 
-            icon_submenu.append_item(&icon_menu_item);
+                icon_submenu.append_item(&icon_menu_item);
 
-            submenu_item.set_submenu(Some(&icon_submenu));
+                submenu_item.set_submenu(Some(&icon_submenu));
 
-            icon_section.append_item(&submenu_item);
+                icon_section.append_item(&submenu_item);
 
-            let cool_section = gtk4::gio::Menu::new();
-            let cool_menu_item = gtk4::gio::MenuItem::new(Some("Be Cool"), Some("muda.cool"));
-            let cool_menu_shortcut_item =
-                gtk4::gio::MenuItem::new(Some("Shortcut"), Some("muda.cool-shortcut"));
+                let cool_section = gtk4::gio::Menu::new();
+                let cool_menu_item = gtk4::gio::MenuItem::new(Some("Be Cool"), Some("muda.cool"));
+                let cool_menu_shortcut_item =
+                    gtk4::gio::MenuItem::new(Some("Shortcut"), Some("muda.cool-shortcut"));
 
-            cool_section.append_item(&cool_menu_item);
-            cool_section.append_item(&cool_menu_shortcut_item);
+                cool_section.append_item(&cool_menu_item);
+                cool_section.append_item(&cool_menu_shortcut_item);
 
-            let program_section = gio::Menu::new();
-            let about_menu_item = gio::MenuItem::new(Some("About"), Some("muda.about"));
-            let quit_menu_item = gio::MenuItem::new(Some("Quit"), Some("muda.quit"));
+                let program_section = gio::Menu::new();
+                let about_menu_item = gio::MenuItem::new(Some("About"), Some("muda.about"));
+                let quit_menu_item = gio::MenuItem::new(Some("Quit"), Some("muda.quit"));
 
-            program_section.append_item(&about_menu_item);
-            program_section.append_item(&quit_menu_item);
+                program_section.append_item(&about_menu_item);
+                program_section.append_item(&quit_menu_item);
 
-            let group = gio::SimpleActionGroup::new();
+                let group = gio::SimpleActionGroup::new();
 
-            group.add_action(&gio::SimpleAction::new_stateful(
-                "cool",
-                None,
-                &true.to_variant(),
-            ));
+                group.add_action(&gio::SimpleAction::new_stateful(
+                    "cool",
+                    None,
+                    &true.to_variant(),
+                ));
 
-            group.add_action(&gio::SimpleAction::new_stateful(
-                "cool-shortcut",
-                None,
-                &true.to_variant(),
-            ));
+                group.add_action(&gio::SimpleAction::new_stateful(
+                    "cool-shortcut",
+                    None,
+                    &true.to_variant(),
+                ));
 
-            group.add_action(&gio::SimpleAction::new("quit", None));
-            group.add_action(&gio::SimpleAction::new("about", None));
-            group.add_action(&gio::SimpleAction::new("icon", None));
-            group.add_action(&gio::SimpleAction::new("icon-accel", None));
+                group.add_action(&gio::SimpleAction::new("quit", None));
+                group.add_action(&gio::SimpleAction::new("about", None));
+                group.add_action(&gio::SimpleAction::new("icon", None));
+                group.add_action(&gio::SimpleAction::new("icon-accel", None));
 
-            window.insert_action_group("muda", Some(&group));
+                window.insert_action_group("muda", Some(&group));
+
+                let file_menu = gtk4::gio::Menu::new();
+
+                file_menu.append_section(None, &icon_section);
+                file_menu.append_section(Some("Cool Header"), &cool_section);
+                file_menu.append_section(None, &program_section);
+
+                file_menu
+            };
+
+            let window_menu_item = {
+                let window_menu = gio::Menu::new();
+
+                let nothing_item =
+                    gio::MenuItem::new(Some("Absolutely Nothing..."), Some("muda.nothing"));
+
+                window_menu.append_item(&nothing_item);
+
+                let window_menu_item = gio::MenuItem::new(Some("Window"), None);
+
+                window_menu_item.set_icon(&icon);
+                window_menu_item.set_submenu(Some(&window_menu));
+
+                window_menu_item
+            };
+
+            let evil_menu = gio::Menu::new();
+            let evil_menu_item = gio::MenuItem::new(Some("Please Put Text On Your Menus :("), None);
+
+            evil_menu.append_item(&evil_menu_item);
+
+            let annoyed_menu_item = gio::MenuItem::new(None, None);
+            annoyed_menu_item.set_icon(&ThemedIcon::from_names(&[
+                "face-plain-symbolic",
+                "face-plain",
+            ]));
+
+            let annoyed_menu = gio::Menu::new();
+            let warning_menu_item =
+                gio::MenuItem::new(Some("Seriously Put Text On Your Menus >:("), None);
+
+            annoyed_menu.append_item(&warning_menu_item);
+            annoyed_menu_item.set_submenu(Some(&annoyed_menu));
 
             let menu = gtk4::gio::Menu::new();
-
-            menu.append_section(None, &icon_section);
-            menu.append_section(Some("Cool Header"), &cool_section);
-            menu.append_section(None, &program_section);
-
+            menu.append_submenu(Some("File"), &file_menu);
+            menu.append_item(&window_menu_item);
+            menu.append_submenu(None, &evil_menu);
+            menu.append_item(&annoyed_menu_item);
             menu
         };
 
@@ -207,13 +250,10 @@ fn setup_muda_menu(container: &gtk4::Box, menu: &gio::Menu) {
 fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
     use gtk4::{PopoverMenu, PopoverMenuBar};
 
-    let submenu_menu = gio::Menu::new();
-    submenu_menu.append_submenu(Some("File"), menu);
-
     let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
     let frame = gtk4::Frame::builder().hexpand(true).vexpand(true).build();
     let menu_bar = PopoverMenuBar::builder()
-        .menu_model(&submenu_menu)
+        .menu_model(menu)
         .valign(gtk4::Align::Start)
         .build();
 
@@ -222,7 +262,7 @@ fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
     let gesture = gtk4::GestureClick::new();
     gesture.set_button(3);
 
-    let popover = PopoverMenu::from_model(Some(menu));
+    let popover = PopoverMenu::from_model(Some(&menu.item_link(0, "submenu").unwrap()));
 
     // TODO: Fix position offset of mouse
     popover.set_position(gtk4::PositionType::Right);

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#![cfg(target_os = "linux")]
 use gtk4::{
     gio::{self, prelude::*, File, FileIcon},
     prelude::*,
@@ -8,12 +8,6 @@ const SPACING: i32 = 8;
 const SPACING_LARGE: i32 = SPACING * 2;
 const SPACING_XLARGE: i32 = SPACING * 4;
 
-#[cfg(not(target_os = "linux"))]
-fn main() {
-    eprintln!("This example is only available on Linux");
-}
-
-#[cfg(target_os = "linux")]
 fn main() {
     let application = gtk4::Application::builder()
         .application_id("com.github.muda.example.gtk")
@@ -112,7 +106,6 @@ fn main() {
     application.run();
 }
 
-#[cfg(target_os = "linux")]
 fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu) {
     let vbox = gtk4::Box::builder()
         .orientation(gtk4::Orientation::Vertical)
@@ -132,7 +125,7 @@ fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu)
         .halign(gtk4::Align::Fill)
         .build();
 
-    setup_gtk_popover_menu(&hbox, menu);
+    setup_muda_menu(&hbox, menu);
     setup_gtk_popover_menu(&hbox, menu);
 
     let image = gtk4::Image::builder()
@@ -149,7 +142,68 @@ fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu)
     window.set_child(Some(&vbox));
 }
 
-#[cfg(target_os = "linux")]
+// TODO: Replace with muda components
+fn setup_muda_menu(container: &gtk4::Box, menu: &gio::Menu) {
+    use gtk4::{PopoverMenu, PopoverMenuBar};
+
+    let submenu_menu = gio::Menu::new();
+    submenu_menu.append_submenu(Some("File"), menu);
+
+    let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
+    let frame = gtk4::Frame::builder().hexpand(true).vexpand(true).build();
+    let menu_bar = PopoverMenuBar::builder()
+        .menu_model(&submenu_menu)
+        .valign(gtk4::Align::Start)
+        .build();
+
+    let inner_vbox = gtk4::Box::new(gtk4::Orientation::Vertical, SPACING);
+
+    let gesture = gtk4::GestureClick::new();
+    gesture.set_button(3);
+
+    let popover = PopoverMenu::from_model(Some(menu));
+
+    // TODO: Fix position offset of mouse
+    popover.set_position(gtk4::PositionType::Right);
+    popover.set_parent(&frame);
+    popover.present();
+
+    gesture.connect_pressed(move |gesture, _, x, y| {
+        use gtk4::gdk::Rectangle;
+
+        println!(
+            "Pressed, x: {x}, y: {y}, button: {}",
+            gesture.current_button()
+        );
+
+        popover.set_pointing_to(Some(&Rectangle::new(x as i32, y as i32, 0, 0)));
+        popover.popup();
+    });
+
+    inner_vbox.add_controller(gesture);
+
+    inner_vbox.append(
+        &gtk4::Label::builder()
+            .label("GTK Widgets\nRight Click to See Context Menu")
+            .justify(gtk4::Justification::Center)
+            .margin_top(SPACING_LARGE)
+            .margin_bottom(SPACING_LARGE)
+            .margin_start(SPACING_XLARGE)
+            .margin_end(SPACING_XLARGE)
+            .valign(gtk4::Align::Center)
+            .xalign(0.5)
+            .vexpand(true)
+            .build(),
+    );
+
+    vbox.append(&menu_bar);
+    vbox.append(&inner_vbox);
+
+    frame.set_child(Some(&vbox));
+
+    container.append(&frame);
+}
+
 fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
     use gtk4::{PopoverMenu, PopoverMenuBar};
 

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,7 +1,6 @@
 #[cfg(target_os = "linux")]
 use gtk4::{
     gio::{self, prelude::*, File, FileIcon},
-    glib,
     prelude::*,
 };
 
@@ -210,16 +209,4 @@ fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
     frame.set_child(Some(&vbox));
 
     container.append(&frame);
-}
-
-fn load_icon(path: &std::path::Path) -> muda::Icon {
-    let (icon_rgba, icon_width, icon_height) = {
-        let image = image::open(path)
-            .expect("Failed to open icon path")
-            .into_rgba8();
-        let (width, height) = image.dimensions();
-        let rgba = image.into_raw();
-        (rgba, width, height)
-    };
-    muda::Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
 }

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -35,74 +35,67 @@ fn main() {
         ))));
 
         let menu = {
-            let file_menu = {
-                let icon_section = gio::Menu::new();
-                let icon_with_label_menu_item =
-                    gio::MenuItem::new(Some("Icon With Label"), Some("muda.icon"));
+            let icon_section = gio::Menu::new();
+            let icon_with_label_menu_item =
+                gio::MenuItem::new(Some("Icon With Label"), Some("muda.icon"));
 
-                icon_with_label_menu_item.set_icon(&icon);
+            icon_with_label_menu_item.set_icon(&icon);
 
-                icon_section.append_item(&icon_with_label_menu_item); 
+            icon_section.append_item(&icon_with_label_menu_item);
 
-                let submenu_item = gio::MenuItem::new(Some("Icon Submenu"), None);
+            let submenu_item = gio::MenuItem::new(Some("Icon Submenu"), None);
 
-                let icon_submenu = gio::Menu::new();
-                let icon_menu_item = gio::MenuItem::new(Some("Icon Accelerator"), Some("muda.icon-accel"));
-                    
-                icon_submenu.append_item(&icon_menu_item);
+            let icon_submenu = gio::Menu::new();
+            let icon_menu_item =
+                gio::MenuItem::new(Some("Icon Accelerator"), Some("muda.icon-accel"));
 
-                submenu_item.set_submenu(Some(&icon_submenu));
+            icon_submenu.append_item(&icon_menu_item);
 
-                icon_section.append_item(&submenu_item); 
+            submenu_item.set_submenu(Some(&icon_submenu));
 
-                let cool_section = gtk4::gio::Menu::new();
-                let cool_menu_item = gtk4::gio::MenuItem::new(Some("Be Cool"), Some("muda.cool"));
-                let cool_menu_shortcut_item =
-                    gtk4::gio::MenuItem::new(Some("Shortcut"), Some("muda.cool-shortcut"));
+            icon_section.append_item(&submenu_item);
 
-                cool_section.append_item(&cool_menu_item);
-                cool_section.append_item(&cool_menu_shortcut_item);
+            let cool_section = gtk4::gio::Menu::new();
+            let cool_menu_item = gtk4::gio::MenuItem::new(Some("Be Cool"), Some("muda.cool"));
+            let cool_menu_shortcut_item =
+                gtk4::gio::MenuItem::new(Some("Shortcut"), Some("muda.cool-shortcut"));
 
-                let program_section = gio::Menu::new();
-                let about_menu_item = gio::MenuItem::new(Some("About"), Some("muda.about"));
-                let quit_menu_item = gio::MenuItem::new(Some("Quit"), Some("muda.quit"));
+            cool_section.append_item(&cool_menu_item);
+            cool_section.append_item(&cool_menu_shortcut_item);
 
-                program_section.append_item(&about_menu_item);
-                program_section.append_item(&quit_menu_item);
+            let program_section = gio::Menu::new();
+            let about_menu_item = gio::MenuItem::new(Some("About"), Some("muda.about"));
+            let quit_menu_item = gio::MenuItem::new(Some("Quit"), Some("muda.quit"));
 
-                let group = gio::SimpleActionGroup::new();
+            program_section.append_item(&about_menu_item);
+            program_section.append_item(&quit_menu_item);
 
-                group.add_action(&gio::SimpleAction::new_stateful(
-                    "cool",
-                    None,
-                    &true.to_variant(),
-                ));
+            let group = gio::SimpleActionGroup::new();
 
-                group.add_action(&gio::SimpleAction::new_stateful(
-                    "cool-shortcut",
-                    None,
-                    &true.to_variant(),
-                ));
+            group.add_action(&gio::SimpleAction::new_stateful(
+                "cool",
+                None,
+                &true.to_variant(),
+            ));
 
-                group.add_action(&gio::SimpleAction::new("quit", None));
-                group.add_action(&gio::SimpleAction::new("about", None));
-                group.add_action(&gio::SimpleAction::new("icon", None));
-                group.add_action(&gio::SimpleAction::new("icon-accel", None));
+            group.add_action(&gio::SimpleAction::new_stateful(
+                "cool-shortcut",
+                None,
+                &true.to_variant(),
+            ));
 
-                window.insert_action_group("muda", Some(&group));
+            group.add_action(&gio::SimpleAction::new("quit", None));
+            group.add_action(&gio::SimpleAction::new("about", None));
+            group.add_action(&gio::SimpleAction::new("icon", None));
+            group.add_action(&gio::SimpleAction::new("icon-accel", None));
 
-                let file_menu = gtk4::gio::Menu::new();
+            window.insert_action_group("muda", Some(&group));
 
-                file_menu.append_section(None, &icon_section);
-                file_menu.append_section(Some("Cool Header"), &cool_section);
-                file_menu.append_section(None, &program_section);
+            let menu = gtk4::gio::Menu::new();
 
-                file_menu
-            };
-
-            let menu = gio::Menu::new();
-
-            menu.append_submenu(Some("File"), &file_menu);
+            menu.append_section(None, &icon_section);
+            menu.append_section(Some("Cool Header"), &cool_section);
+            menu.append_section(None, &program_section);
 
             menu
         };
@@ -110,7 +103,6 @@ fn main() {
         application.set_accels_for_action("muda.about", &["<Control>C"]);
         application.set_accels_for_action("muda.quit", &["<Control>Q"]);
         application.set_accels_for_action("muda.cool-shortcut", &["<Control>W"]);
-
         application.set_accels_for_action("muda.icon-accel", &["<Control>I"]);
 
         setup_ui(&window, &icon, &menu);
@@ -160,17 +152,45 @@ fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu)
 
 #[cfg(target_os = "linux")]
 fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
-    use gtk4::PopoverMenuBar;
+    use gtk4::{PopoverMenu, PopoverMenuBar};
 
-    let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, SPACING);
+    let submenu_menu = gio::Menu::new();
+    submenu_menu.append_submenu(Some("File"), menu);
+
+    let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
     let frame = gtk4::Frame::builder().hexpand(true).vexpand(true).build();
     let menu_bar = PopoverMenuBar::builder()
-        .menu_model(menu)
+        .menu_model(&submenu_menu)
         .valign(gtk4::Align::Start)
         .build();
 
-    vbox.append(&menu_bar);
-    vbox.append(
+    let inner_vbox = gtk4::Box::new(gtk4::Orientation::Vertical, SPACING);
+
+    let gesture = gtk4::GestureClick::new();
+    gesture.set_button(3);
+
+    let popover = PopoverMenu::from_model(Some(menu));
+
+    // TODO: Fix position offset of mouse
+    popover.set_position(gtk4::PositionType::Right);
+    popover.set_parent(&frame);
+    popover.present();
+
+    gesture.connect_pressed(move |gesture, _, x, y| {
+        use gtk4::gdk::Rectangle;
+
+        println!(
+            "Pressed, x: {x}, y: {y}, button: {}",
+            gesture.current_button()
+        );
+
+        popover.set_pointing_to(Some(&Rectangle::new(x as i32, y as i32, 0, 0)));
+        popover.popup();
+    });
+
+    inner_vbox.add_controller(gesture);
+
+    inner_vbox.append(
         &gtk4::Label::builder()
             .label("GTK Widgets\nRight Click to See Context Menu")
             .justify(gtk4::Justification::Center)
@@ -183,6 +203,9 @@ fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
             .vexpand(true)
             .build(),
     );
+
+    vbox.append(&menu_bar);
+    vbox.append(&inner_vbox);
 
     frame.set_child(Some(&vbox));
 

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,0 +1,202 @@
+#[cfg(target_os = "linux")]
+use gtk4::{
+    gio::{self, prelude::*, File, FileIcon},
+    glib,
+    prelude::*,
+};
+
+const SPACING: i32 = 8;
+const SPACING_LARGE: i32 = SPACING * 2;
+const SPACING_XLARGE: i32 = SPACING * 4;
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("This example is only available on Linux");
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    let application = gtk4::Application::builder()
+        .application_id("com.github.muda.example.gtk")
+        .build();
+
+    application.connect_activate(move |application| {
+        let window = gtk4::ApplicationWindow::builder()
+            .application(application)
+            .title("GTK Menubar Example")
+            .default_width(350)
+            .default_height(350)
+            .show_menubar(true)
+            .build();
+
+        let icon = FileIcon::new(&File::for_path(std::path::Path::new(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/examples/icon.png"
+        ))));
+
+        let menu = {
+            let file_menu = {
+                let icon_section = gio::Menu::new();
+                let icon_with_label_menu_item =
+                    gio::MenuItem::new(Some("Icon With Label"), Some("muda.icon"));
+
+                icon_with_label_menu_item.set_icon(&icon);
+
+                icon_section.append_item(&icon_with_label_menu_item); 
+
+                let submenu_item = gio::MenuItem::new(Some("Icon Submenu"), None);
+
+                let icon_submenu = gio::Menu::new();
+                let icon_menu_item = gio::MenuItem::new(Some("Icon Accelerator"), Some("muda.icon-accel"));
+                    
+                icon_submenu.append_item(&icon_menu_item);
+
+                submenu_item.set_submenu(Some(&icon_submenu));
+
+                icon_section.append_item(&submenu_item); 
+
+                let cool_section = gtk4::gio::Menu::new();
+                let cool_menu_item = gtk4::gio::MenuItem::new(Some("Be Cool"), Some("muda.cool"));
+                let cool_menu_shortcut_item =
+                    gtk4::gio::MenuItem::new(Some("Shortcut"), Some("muda.cool-shortcut"));
+
+                cool_section.append_item(&cool_menu_item);
+                cool_section.append_item(&cool_menu_shortcut_item);
+
+                let program_section = gio::Menu::new();
+                let about_menu_item = gio::MenuItem::new(Some("About"), Some("muda.about"));
+                let quit_menu_item = gio::MenuItem::new(Some("Quit"), Some("muda.quit"));
+
+                program_section.append_item(&about_menu_item);
+                program_section.append_item(&quit_menu_item);
+
+                let group = gio::SimpleActionGroup::new();
+
+                group.add_action(&gio::SimpleAction::new_stateful(
+                    "cool",
+                    None,
+                    &true.to_variant(),
+                ));
+
+                group.add_action(&gio::SimpleAction::new_stateful(
+                    "cool-shortcut",
+                    None,
+                    &true.to_variant(),
+                ));
+
+                group.add_action(&gio::SimpleAction::new("quit", None));
+                group.add_action(&gio::SimpleAction::new("about", None));
+                group.add_action(&gio::SimpleAction::new("icon", None));
+                group.add_action(&gio::SimpleAction::new("icon-accel", None));
+
+                window.insert_action_group("muda", Some(&group));
+
+                let file_menu = gtk4::gio::Menu::new();
+
+                file_menu.append_section(None, &icon_section);
+                file_menu.append_section(Some("Cool Header"), &cool_section);
+                file_menu.append_section(None, &program_section);
+
+                file_menu
+            };
+
+            let menu = gio::Menu::new();
+
+            menu.append_submenu(Some("File"), &file_menu);
+
+            menu
+        };
+
+        application.set_accels_for_action("muda.about", &["<Control>C"]);
+        application.set_accels_for_action("muda.quit", &["<Control>Q"]);
+        application.set_accels_for_action("muda.cool-shortcut", &["<Control>W"]);
+
+        application.set_accels_for_action("muda.icon-accel", &["<Control>I"]);
+
+        setup_ui(&window, &icon, &menu);
+
+        window.present();
+    });
+
+    application.run();
+}
+
+#[cfg(target_os = "linux")]
+fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu) {
+    let vbox = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Vertical)
+        .spacing(SPACING)
+        .margin_top(SPACING_LARGE)
+        .margin_bottom(SPACING_LARGE)
+        .hexpand(true)
+        .halign(gtk4::Align::Fill)
+        .build();
+
+    let hbox = gtk4::Box::builder()
+        .orientation(gtk4::Orientation::Horizontal)
+        .spacing(SPACING)
+        .margin_start(SPACING)
+        .margin_end(SPACING)
+        .hexpand(true)
+        .halign(gtk4::Align::Fill)
+        .build();
+
+    setup_gtk_popover_menu(&hbox, menu);
+    setup_gtk_popover_menu(&hbox, menu);
+
+    let image = gtk4::Image::builder()
+        .gicon(icon)
+        .icon_size(gtk4::IconSize::Large)
+        .build();
+
+    vbox.append(&hbox);
+    vbox.append(&image);
+    vbox.append(&gtk4::Label::new(Some(
+        "Some menu items should have this icon",
+    )));
+
+    window.set_child(Some(&vbox));
+}
+
+#[cfg(target_os = "linux")]
+fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
+    use gtk4::PopoverMenuBar;
+
+    let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, SPACING);
+    let frame = gtk4::Frame::builder().hexpand(true).vexpand(true).build();
+    let menu_bar = PopoverMenuBar::builder()
+        .menu_model(menu)
+        .valign(gtk4::Align::Start)
+        .build();
+
+    vbox.append(&menu_bar);
+    vbox.append(
+        &gtk4::Label::builder()
+            .label("GTK Widgets\nRight Click to See Context Menu")
+            .justify(gtk4::Justification::Center)
+            .margin_top(SPACING_LARGE)
+            .margin_bottom(SPACING_LARGE)
+            .margin_start(SPACING_XLARGE)
+            .margin_end(SPACING_XLARGE)
+            .valign(gtk4::Align::Center)
+            .xalign(0.5)
+            .vexpand(true)
+            .build(),
+    );
+
+    frame.set_child(Some(&vbox));
+
+    container.append(&frame);
+}
+
+fn load_icon(path: &std::path::Path) -> muda::Icon {
+    let (icon_rgba, icon_width, icon_height) = {
+        let image = image::open(path)
+            .expect("Failed to open icon path")
+            .into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        (rgba, width, height)
+    };
+    muda::Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+}

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,8 +1,10 @@
 #![cfg(target_os = "linux")]
+
 use gtk4::{
     gio::{self, prelude::*, File, FileIcon, ThemedIcon},
     prelude::*,
 };
+use muda::gtk_widgets::{self, MenuBar};
 
 const SPACING: i32 = 8;
 const SPACING_LARGE: i32 = SPACING * 2;
@@ -187,47 +189,27 @@ fn setup_ui(window: &gtk4::ApplicationWindow, icon: &FileIcon, menu: &gio::Menu)
 
 // TODO: Replace with muda components
 fn setup_muda_menu(container: &gtk4::Box, menu: &gio::Menu) {
-    use gtk4::{PopoverMenu, PopoverMenuBar};
-
-    let submenu_menu = gio::Menu::new();
-    submenu_menu.append_submenu(Some("File"), menu);
-
     let vbox = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
     let frame = gtk4::Frame::builder().hexpand(true).vexpand(true).build();
-    let menu_bar = PopoverMenuBar::builder()
-        .menu_model(&submenu_menu)
-        .valign(gtk4::Align::Start)
-        .build();
+    let menu_bar = MenuBar::new(menu.clone());
 
     let inner_vbox = gtk4::Box::new(gtk4::Orientation::Vertical, SPACING);
 
     let gesture = gtk4::GestureClick::new();
     gesture.set_button(3);
 
-    let popover = PopoverMenu::from_model(Some(menu));
-
-    // TODO: Fix position offset of mouse
-    popover.set_position(gtk4::PositionType::Right);
-    popover.set_parent(&frame);
-    popover.present();
-
     gesture.connect_pressed(move |gesture, _, x, y| {
-        use gtk4::gdk::Rectangle;
-
         println!(
             "Pressed, x: {x}, y: {y}, button: {}",
             gesture.current_button()
         );
-
-        popover.set_pointing_to(Some(&Rectangle::new(x as i32, y as i32, 0, 0)));
-        popover.popup();
     });
 
     inner_vbox.add_controller(gesture);
 
     inner_vbox.append(
         &gtk4::Label::builder()
-            .label("GTK Widgets\nRight Click to See Context Menu")
+            .label("Muda Widgets\nRight Click to See Context Menu")
             .justify(gtk4::Justification::Center)
             .margin_top(SPACING_LARGE)
             .margin_bottom(SPACING_LARGE)

--- a/examples/gtk_widgets.rs
+++ b/examples/gtk_widgets.rs
@@ -1,8 +1,7 @@
 #![cfg(target_os = "linux")]
 
 use gtk4::{
-    gio::{self, prelude::*, File, FileIcon, ThemedIcon},
-    prelude::*,
+    PopoverMenuFlags, gio::{self, File, FileIcon, ThemedIcon, prelude::*}, prelude::*
 };
 use muda::gtk_widgets::{self, MenuBar};
 
@@ -244,7 +243,7 @@ fn setup_gtk_popover_menu(container: &gtk4::Box, menu: &gio::Menu) {
     let gesture = gtk4::GestureClick::new();
     gesture.set_button(3);
 
-    let popover = PopoverMenu::from_model(Some(&menu.item_link(0, "submenu").unwrap()));
+    let popover = PopoverMenu::from_model_full(&menu.item_link(0, "submenu").unwrap(), PopoverMenuFlags::NESTED);
 
     // TODO: Fix position offset of mouse
     popover.set_position(gtk4::PositionType::Right);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,9 @@ mod menu_id;
 mod platform_impl;
 mod util;
 
+#[cfg(target_os = "linux")]
+pub use platform_impl::widgets as gtk_widgets;
+
 pub use about_metadata::AboutMetadata;
 pub use builders::*;
 pub use dpi;

--- a/src/platform_impl/gtk/mod.rs
+++ b/src/platform_impl/gtk/mod.rs
@@ -6,6 +6,9 @@ mod accelerator;
 mod icon;
 mod mnemonic;
 
+#[cfg(target_os = "linux")]
+pub mod widgets;
+
 use std::{
     cell::RefCell,
     collections::{hash_map::Entry, HashMap},
@@ -14,8 +17,9 @@ use std::{
 
 use dpi::Position;
 use gtk4::{gdk::Rectangle, gio, prelude::*};
-pub(crate) use icon::PlatformIcon;
 use mnemonic::to_gtk_mnemonic;
+
+pub(crate) use icon::PlatformIcon;
 
 use crate::{
     accelerator::Accelerator,

--- a/src/platform_impl/gtk/widgets.rs
+++ b/src/platform_impl/gtk/widgets.rs
@@ -1,3 +1,16 @@
+use gio::prelude::*;
+use gtk4::{gio, glib};
+
 mod menubar;
+
+fn get_icon_for_item(menu: &gio::Menu, index: i32) -> Option<gio::Icon> {
+    menu.item_attribute_value(index, "icon", None)
+        .and_then(|v| gio::Icon::deserialize(&v))
+}
+
+fn get_label_for_item(menu: &gio::Menu, index: i32) -> Option<String> {
+    menu.item_attribute_value(index, "label", Some(glib::VariantTy::STRING))
+        .and_then(|v| v.str().map(String::from))
+}
 
 pub use menubar::*;

--- a/src/platform_impl/gtk/widgets.rs
+++ b/src/platform_impl/gtk/widgets.rs
@@ -1,0 +1,3 @@
+mod menubar;
+
+pub use menubar::*;

--- a/src/platform_impl/gtk/widgets/menubar.rs
+++ b/src/platform_impl/gtk/widgets/menubar.rs
@@ -1,0 +1,51 @@
+use gtk4::{gio, glib};
+
+mod imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    use glib::Properties;
+    use gtk4::{prelude::*, subclass::prelude::*, BoxLayout, Orientation};
+
+    #[derive(Default, Properties, Debug)]
+    #[properties(wrapper_type = super::MenuBar)]
+    pub struct MenuBar {
+        #[property(get, set)]
+        pub menu_model: RefCell<gio::Menu>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MenuBar {
+        const NAME: &'static str = "MudaMenuBar";
+        type Type = super::MenuBar;
+        type ParentType = gtk4::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("menubar")
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for MenuBar {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj()
+                .set_layout_manager(Some(BoxLayout::new(Orientation::Horizontal)));
+        }
+    }
+
+    impl WidgetImpl for MenuBar {}
+}
+
+glib::wrapper! {
+    pub struct MenuBar(ObjectSubclass<imp::MenuBar>)
+        @extends gtk4::Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl MenuBar {
+    pub fn new(menu: gio::Menu) -> Self {
+        glib::Object::builder().property("menu-model", menu).build()
+    }
+}

--- a/src/platform_impl/gtk/widgets/menubar.rs
+++ b/src/platform_impl/gtk/widgets/menubar.rs
@@ -1,17 +1,81 @@
+use gtk4::prelude::WidgetExt;
+use gtk4::subclass::prelude::*;
 use gtk4::{gio, glib};
 
+mod item;
+use item::*;
+
 mod imp {
+    use crate::gtk_widgets::{get_icon_for_item, get_label_for_item};
+
     use super::*;
     use std::cell::RefCell;
 
     use glib::Properties;
-    use gtk4::{prelude::*, subclass::prelude::*, BoxLayout, Orientation};
+    use gtk4::{prelude::*, BoxLayout, Orientation};
 
     #[derive(Default, Properties, Debug)]
     #[properties(wrapper_type = super::MenuBar)]
     pub struct MenuBar {
-        #[property(get, set)]
+        #[property(get, set = set_menu_model)]
         pub menu_model: RefCell<gio::Menu>,
+        pub active_item: RefCell<Option<MenuBarItem>>,
+        items: RefCell<Vec<MenuBarItem>>,
+    }
+
+    fn set_menu_model(item: &MenuBar, menu: gio::Menu) {
+        item.menu_model.replace(menu);
+
+        item.build_menu_bar();
+    }
+
+    impl MenuBar {
+        pub fn build_menu_bar(&self) {
+            let mut items = self.items.borrow_mut();
+            for item in items.drain(..) {
+                item.unparent();
+            }
+
+            let menu = self.menu_model.borrow().clone();
+
+            let obj = self.obj();
+            for index in 0..menu.n_items() {
+                if menu.item_link(index, "submenu").is_some() {
+                    let item = MenuBarItem::new(
+                        get_label_for_item(&menu, index)
+                            .unwrap_or_default()
+                            .as_ref(),
+                        get_icon_for_item(&menu, index).as_ref(),
+                    );
+
+                    item.set_parent(obj.upcast_ref::<gtk4::Widget>());
+                    items.push(item);
+                }
+            }
+        }
+
+        pub fn set_active_item(&self, item: Option<MenuBarItem>, _open_popup: bool) {
+            let mut active_item = self.active_item.borrow_mut();
+
+            let item_changed = active_item.as_ref() != item.as_ref();
+            if item_changed {
+                if let Some(item) = active_item.as_ref() {
+                    item.set_selected(false);
+                }
+
+                if let Some(item) = item.as_ref() {
+                    item.set_selected(true);
+                }
+            }
+
+            if let Some(item) = item.as_ref() {
+                if _open_popup {
+                    item.grab_focus();
+                }
+            }
+
+            *active_item = item;
+        }
     }
 
     #[glib::object_subclass]
@@ -30,12 +94,73 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
 
-            self.obj()
-                .set_layout_manager(Some(BoxLayout::new(Orientation::Horizontal)));
+            let obj = self.obj();
+            let motion_controller = gtk4::EventControllerMotion::new();
+
+            motion_controller.connect_leave(|motion| {
+                let menu_bar = motion
+                    .widget()
+                    .expect("Cannot get motion widget")
+                    .downcast::<super::MenuBar>()
+                    .unwrap();
+
+                menu_bar.set_active_item(None, false);
+            });
+
+            obj.add_controller(motion_controller);
+
+            obj.set_layout_manager(Some(BoxLayout::new(Orientation::Horizontal)));
         }
     }
 
-    impl WidgetImpl for MenuBar {}
+    impl WidgetImpl for MenuBar {
+        fn focus(&self, direction_type: gtk4::DirectionType) -> bool {
+            let obj = self.obj();
+
+            match direction_type {
+                gtk4::DirectionType::Left => {
+                    let previous = self
+                        .active_item
+                        .borrow()
+                        .as_ref()
+                        .and_then(|item| {
+                            item.prev_sibling()
+                                .and_then(|sibling| sibling.downcast_ref::<MenuBarItem>().cloned())
+                        })
+                        .or_else(|| {
+                            obj.first_child()
+                                .and_then(|child| child.downcast_ref::<MenuBarItem>().cloned())
+                        });
+
+                    if let Some(previous) = previous {
+                        self.set_active_item(Some(previous), false);
+                    }
+                }
+
+                gtk4::DirectionType::Right => {
+                    let next = self
+                        .active_item
+                        .borrow()
+                        .as_ref()
+                        .and_then(|item| {
+                            item.next_sibling()
+                                .and_then(|sibling| sibling.downcast_ref::<MenuBarItem>().cloned())
+                        })
+                        .or_else(|| {
+                            obj.last_child()
+                                .and_then(|child| child.downcast_ref::<MenuBarItem>().cloned())
+                        });
+
+                    if let Some(next) = next {
+                        self.set_active_item(Some(next), false);
+                    }
+                }
+                _ => (),
+            }
+
+            true
+        }
+    }
 }
 
 glib::wrapper! {
@@ -47,5 +172,9 @@ glib::wrapper! {
 impl MenuBar {
     pub fn new(menu: gio::Menu) -> Self {
         glib::Object::builder().property("menu-model", menu).build()
+    }
+
+    pub(crate) fn set_active_item(&self, item: Option<MenuBarItem>, _open_popup: bool) {
+        self.imp().set_active_item(item, _open_popup);
     }
 }

--- a/src/platform_impl/gtk/widgets/menubar/item.rs
+++ b/src/platform_impl/gtk/widgets/menubar/item.rs
@@ -1,0 +1,151 @@
+use gtk4::{
+    gio,
+    glib::{self, object::ObjectExt, subclass::prelude::*},
+    prelude::WidgetExt,
+    StateFlags,
+};
+
+mod imp {
+    use std::cell::RefCell;
+
+    use crate::gtk_widgets::MenuBar;
+
+    use super::*;
+    use gtk4::{glib::Properties, prelude::*, subclass::prelude::*, BinLayout, Orientation};
+
+    #[derive(Default, Properties, Debug)]
+    #[properties(wrapper_type = super::MenuBarItem)]
+    pub struct MenuBarItem {
+        pub image: gtk4::Image,
+        pub label: gtk4::Label,
+
+        #[property(get, set)]
+        pub icon: RefCell<Option<gio::Icon>>,
+
+        #[property(get, set)]
+        pub label_text: RefCell<String>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for MenuBarItem {
+        const NAME: &'static str = "MudaMenuBarItem";
+        type Type = super::MenuBarItem;
+        type ParentType = gtk4::Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_css_name("item");
+            klass.set_accessible_role(gtk4::AccessibleRole::MenuItem);
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for MenuBarItem {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            let hbox = gtk4::Box::builder()
+                .orientation(Orientation::Horizontal)
+                .spacing(4)
+                .build();
+
+            let label = &self.label;
+            label.set_use_underline(true);
+
+            hbox.append(&self.image);
+            hbox.append(label);
+
+            let obj = self.obj();
+
+            obj.set_focusable(true);
+            obj.set_cursor_from_name(Some("pointer"));
+
+            let click_gesture = gtk4::GestureClick::new();
+            click_gesture.connect_pressed(move |gesture, _, _, _| {
+                let item = gesture
+                    .widget()
+                    .expect("Cannot get gesture widget")
+                    .downcast::<super::MenuBarItem>()
+                    .unwrap();
+
+                let menu_bar = item
+                    .ancestor(MenuBar::static_type())
+                    .expect("Menu bar doesn't exist")
+                    .downcast::<MenuBar>()
+                    .unwrap();
+
+                menu_bar.set_active_item(Some(item), true);
+            });
+
+            obj.add_controller(click_gesture);
+
+            let motion_controller = gtk4::EventControllerMotion::new();
+            motion_controller.connect_enter(move |motion, _, _| {
+                let item = motion
+                    .widget()
+                    .expect("Cannot get motion widget")
+                    .downcast::<super::MenuBarItem>()
+                    .unwrap();
+                let menu_bar = item
+                    .ancestor(MenuBar::static_type())
+                    .expect("Menu bar doesn't exist")
+                    .downcast::<MenuBar>()
+                    .unwrap();
+
+                menu_bar.set_active_item(Some(item), false);
+            });
+
+            obj.add_controller(motion_controller);
+
+            obj.bind_property("icon", &self.image, "gicon")
+                .sync_create()
+                .build();
+
+            obj.bind_property("icon", &self.image, "visible")
+                .sync_create()
+                .transform_to(|_, value: Option<gio::Icon>| {
+                    Some(value.is_some())
+                })
+                .build();
+
+            obj.bind_property("label-text", &self.label, "label")
+                .sync_create()
+                .build();
+
+            obj.bind_property("label-text", label, "visible")
+                .sync_create()
+                .transform_to(|_, value: Option<String>| {
+                    Some(value.as_ref().map(|s| !s.is_empty()).unwrap_or(false))
+                })
+                .build();
+
+            obj.set_layout_manager(Some(BinLayout::new()));
+
+            hbox.set_parent(obj.upcast_ref::<gtk4::Widget>());
+        }
+    }
+
+    impl WidgetImpl for MenuBarItem {}
+}
+
+glib::wrapper! {
+    pub struct MenuBarItem(ObjectSubclass<imp::MenuBarItem>)
+        @extends gtk4::Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl MenuBarItem {
+    pub fn new(label: &str, icon: Option<&gio::Icon>) -> Self {
+        glib::Object::builder()
+            .property("label-text", label)
+            .property("icon", icon)
+            .build()
+    }
+
+    pub(crate) fn set_selected(&self, active: bool) {
+        if active {
+            self.set_state_flags(StateFlags::SELECTED, false);
+        } else {
+            self.unset_state_flags(StateFlags::SELECTED);
+        }
+    }
+}

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -21,6 +21,9 @@ use crate::{items::*, IsMenuItem, MenuItemKind, MenuItemType};
 
 pub(crate) use self::platform::*;
 
+#[cfg(target_os = "linux")]
+pub use self::platform::{widgets};
+
 impl dyn IsMenuItem + '_ {
     fn child(&self) -> Rc<RefCell<MenuChild>> {
         match self.kind() {


### PR DESCRIPTION
After messing around with `gtk4-rs` to see if we could get icons on the [`PopoverMenuBar`](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/struct.PopoverMenuBar.html) and [`PopoverMenu`](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/struct.PopoverMenu.html), I had no luck.

After researching and looking at the `gtk` source code, I made a [discovery](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkmodelbutton.c?ref_type=heads#L646-668):
```c
static void
update_visibility (GtkModelButton *self)
{
  gboolean has_icon;
  gboolean has_text;

  has_icon = self->image && gtk_image_get_storage_type (GTK_IMAGE (self->image)) != GTK_IMAGE_EMPTY;
  has_text = gtk_label_get_text (GTK_LABEL (self->label))[0] != '\0';

  gtk_widget_set_visible (self->label, has_text && (!self->iconic || !has_icon));
  gtk_widget_set_hexpand (self->label,
                          gtk_widget_get_visible (self->label) && !has_icon);

  if (self->accel_label)
    gtk_widget_set_visible (self->accel_label, has_text && (!self->iconic || !has_icon));

  if (self->image)
    {
      gtk_widget_set_visible (self->image, has_icon && (self->iconic || !has_text));
      gtk_widget_set_hexpand (self->image,
                              has_icon && (!has_text || !gtk_widget_get_visible (self->label)));
    }
}
```

while [`GtkPopverMenu`](https://docs.gtk.org/gtk4/class.PopoverMenu.html) does watch for an `icon` attribute on an [`GMenuItem`](https://docs.gtk.org/gio/class.MenuItem.html) it does not display it if has a text with it.

Additionally from what I could [find](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkpopovermenubar.c), [`GtkPopoverMenuBar`](https://docs.gtk.org/gtk4/class.PopoverMenuBar.html) doesn't even look for icon.

So that leads me to the conclusion in order to keep icon support, we have to create custom widget versions of [`GtkPopverMenu`](https://docs.gtk.org/gtk4/class.PopoverMenu.html) and [`GtkPopoverMenuBar`](https://docs.gtk.org/gtk4/class.PopoverMenuBar.html).

So far I've gotten moderate success with recreating [`GtkPopoverMenuBar`](https://docs.gtk.org/gtk4/class.PopoverMenuBar.html) example below.

<img width="564" height="350" alt="Screenshot From 2025-11-22 10-56-28" src="https://github.com/user-attachments/assets/61618cdf-8382-422a-9931-3a3400e7548c" />

I've done this before for creating a custom font family chooser dropdown, it's not necessarily _easy_ but it is doable from my experience.

I've gathered some source files and how it looks like they are structured if anyone is interested in helping:

- [`gtkpopovermenubar.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkpopovermenubar.c)
- [`gtkpopovermenu.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkpopovermenu.c)
    - [`gtkmenusectionbox.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkmenusectionbox.c)
    - [`gtkmodelbutton.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkmodelbutton.c)
- [`gtkmenutracker.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkmenutracker.c)
    - [`gtkmenutrackeritem.c`](https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gtk/gtkmenutrackeritem.c)

Additionally I'd like to get `separators` working again, possibly creating a custom object that extends [`GMenuModel`](https://docs.gtk.org/gio/class.MenuModel.html) so we can control how the menus are built but I haven't tested that yet.

I currently haven't touched anything about the `gtk` back-end so I've marked this as draft request, but the end goal is to use the custom widgets for said back-end.

I personally don't see the need for icons for menu bars but I'm not okay with limiting developers.

I've also made an example to test the compatibility between the `gtk4` widgets and the custom widgets, you can run it using the following:

 ```bash
cargo run --example gtk_widgets
```

## Tasks

  - [ ] Replace widgets in `gtk` back-end with newly created widgets.
  - [x] Create `MenuBar` widget
      - [x] Display Items with submenus from `GMenuModel`
          - [x] Display icons and labels 
      - [ ] Make keyboard accessible
          - [x] Left and Right arrow keys cycle through items
          - [ ] When cycling through items close current submenu and open submenu of the next item if menu was opened.
          - [ ] Down arrow key opens active item's submenu.
  - [ ] Create `PopoverMenu` widget.
      - [ ] Display Items.
          - [ ] Display icons and labels if item is normal.
          - [ ] Display accelerator if action has one.
          - [ ] Display checkbox if action has boolean state.
          - [ ] Display right arrow at end if item has submenu.
          - [ ] Display separators.
      - [ ] Active items displays submenu if selected and item has submenu
      - [ ] Make keyboard accessible.
          - [ ] Up and Down arrow key cycles through items.
          - [ ] Right arrow key goes into nested submenu if item has a submenu.
          - [ ] Left arrow key exits submenu goes to parent submenu if submenu is nested.
          - [ ] Enter key activates item.
  - [ ] Add ability to add separator item that groups items after it so `muda` can use it

## Final Thoughts

Helps with #270, #259, and #272

Please let me know if what I'm doing is unwanted or if you have any feedback!
