### PR TITLE
feat: make MenuEvent::send public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,7 +587,12 @@ impl MenuEvent {
         }
     }
 
-    pub(crate) fn send(event: MenuEvent) {
+    /// Dispatches a menu event to the handler, or to the channel returned by
+    /// [`MenuEvent::receiver`] when no handler is set.
+    ///
+    /// Menus rendered by something other than muda, such as a tray serving its
+    /// own menu over StatusNotifierItem, have to report activation themselves.
+    pub fn send(event: MenuEvent) {
         if let Some(handler) = MENU_EVENT_HANDLER.get_or_init(|| None) {
             handler(event);
         } else {


### PR DESCRIPTION
A menu can be rendered by something other than muda. A tray serving its menu over StatusNotifierItem builds the items from muda's model but receives the clicks itself, and currently has no way to report them back: `send` is the only path to both the handler and the receiver channel, and it is `pub(crate)`.

Needed by [tray-icon#341](https://github.com/tauri-apps/tray-icon/pull/341), which adds a StatusNotifierItem backend so left clicks work on Linux. Without this the backend can serve the menu but cannot deliver activation events, so `MenuEvent::receiver()` stays silent.

No behaviour change; only the visibility of an existing function.