### PR TITLE
feat(macos): add MenuItem::set_attributed_title for custom NSAttributedString labels

### DIFF
--- a/.changes/macos-attributed-title.md
+++ b/.changes/macos-attributed-title.md
@@ -1,0 +1,5 @@
+---
+"muda": minor
+---
+
+**macOS**: Add `MenuItem::set_attributed_title` to set a fully custom `NSAttributedString` as a menu item's label. This is an escape hatch for layouts and colors the semantic `set_styled_text` API cannot express, such as a right-aligned trailing segment (via an `NSParagraphStyle` with a right `NSTextTab`, as the system battery menu does) or a custom foreground color to tint a whole row. Passing `None` clears it and falls back to the plain text.

--- a/src/items/normal.rs
+++ b/src/items/normal.rs
@@ -1,5 +1,10 @@
 use std::{cell::RefCell, mem, rc::Rc};
 
+#[cfg(target_os = "macos")]
+use objc2::{rc::Retained, Message};
+#[cfg(target_os = "macos")]
+use objc2_foundation::NSAttributedString;
+
 use crate::{
     accelerator::{Accelerator, KeyAccelerator, MenuAccelerator},
     platform_impl::PlatformMenuItem,
@@ -25,6 +30,11 @@ pub(crate) struct MenuItemState {
     pub enabled: bool,
     pub accelerator: Option<MenuAccelerator>,
     pub styled_text: Option<Vec<(String, TextStyle)>>,
+    /// macOS-only fully custom attributed title set via
+    /// [`MenuItem::set_attributed_title`]. When present it takes precedence over
+    /// `text`/`styled_text` when the native item is (re)created.
+    #[cfg(target_os = "macos")]
+    pub attributed_title: Option<Retained<NSAttributedString>>,
 }
 
 impl IsMenuItemBase for MenuItem {}
@@ -91,6 +101,8 @@ impl MenuItem {
             enabled,
             accelerator,
             styled_text: None,
+            #[cfg(target_os = "macos")]
+            attributed_title: None,
         };
         let click = ClickAction::Emit(id.clone());
         let platform = PlatformMenuItem::new(click);
@@ -125,6 +137,10 @@ impl MenuItem {
             let mut state = self.state.borrow_mut();
             state.text = text.as_ref().to_string();
             state.styled_text = None;
+            #[cfg(target_os = "macos")]
+            {
+                state.attributed_title = None;
+            }
             state.accelerator.clone()
         };
 
@@ -143,11 +159,41 @@ impl MenuItem {
             let mut state = self.state.borrow_mut();
             state.text = parts.iter().map(|(text, _)| text.as_str()).collect();
             state.styled_text = Some(parts.clone());
+            #[cfg(target_os = "macos")]
+            {
+                state.attributed_title = None;
+            }
             (state.text.clone(), state.accelerator.clone())
         };
         self.platform
             .borrow_mut()
             .set_styled_text(&text, &parts, accelerator.as_ref())
+    }
+
+    /// Set the item's label to a fully custom [`NSAttributedString`] (macOS only).
+    ///
+    /// This is an escape hatch for layouts and colors that the semantic
+    /// [`set_styled_text`](Self::set_styled_text) API cannot express — for
+    /// example a right-aligned trailing segment (built with an `NSParagraphStyle`
+    /// that has a right-aligned `NSTextTab` and a `\t` separator, as the system
+    /// battery menu does) or a custom `NSForegroundColorAttributeName` used to
+    /// tint a whole row. Because the caller supplies raw attributes, it is the
+    /// caller's responsibility to keep the label legible in light and dark modes,
+    /// under increased contrast, and when the system menu font changes.
+    ///
+    /// The attributed title takes precedence over any [`set_text`](Self::set_text)
+    /// or [`set_styled_text`](Self::set_styled_text) value until it is cleared.
+    /// Pass `None` to clear it and fall back to the plain text.
+    #[cfg(target_os = "macos")]
+    pub fn set_attributed_title(&self, title: Option<&NSAttributedString>) {
+        let title = {
+            let mut state = self.state.borrow_mut();
+            state.attributed_title = title.map(|t| t.retain());
+            state.attributed_title.clone()
+        };
+        self.platform
+            .borrow_mut()
+            .set_attributed_title(title.as_deref());
     }
 
     /// Get whether this menu item is enabled or not.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -292,6 +292,14 @@ impl PlatformMenuItem {
         }
     }
 
+    pub fn set_attributed_title(&mut self, title: Option<&NSAttributedString>) {
+        for ns_items in self.ns_menu_items.values() {
+            for ns_item in ns_items {
+                ns_item.setAttributedTitle(title);
+            }
+        }
+    }
+
     pub fn is_enabled(&self) -> Option<bool> {
         self.ns_menu_items
             .values()
@@ -997,6 +1005,9 @@ impl MenuItemKind {
                 .map(|(text, style)| (strip_mnemonic(text), *style))
                 .collect::<Vec<_>>();
             ns_item.setAttributedTitle(Some(&build_attributed_title(&parts)));
+        }
+        if let Some(title) = &args.attributed_title {
+            ns_item.setAttributedTitle(Some(title));
         }
         Ok(ns_item)
     }

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -36,6 +36,11 @@ mod platform;
 use std::{cell::RefCell, rc::Rc};
 
 #[cfg(target_os = "macos")]
+use objc2::rc::Retained;
+#[cfg(target_os = "macos")]
+use objc2_foundation::NSAttributedString;
+
+#[cfg(target_os = "macos")]
 use crate::TextStyle;
 use crate::{accelerator::MenuAccelerator, items::IconType, MenuItemKind};
 
@@ -62,6 +67,8 @@ pub(crate) struct PlatformAttachArgs {
     pub icon: Option<IconType>,
     #[cfg(target_os = "macos")]
     pub styled_text: Option<Vec<(String, TextStyle)>>,
+    #[cfg(target_os = "macos")]
+    pub attributed_title: Option<Retained<NSAttributedString>>,
 }
 
 impl MenuItemKind {
@@ -77,6 +84,8 @@ impl MenuItemKind {
                     icon: None,
                     #[cfg(target_os = "macos")]
                     styled_text: state.styled_text.clone(),
+                    #[cfg(target_os = "macos")]
+                    attributed_title: state.attributed_title.clone(),
                 }
             }
             MenuItemKind::Submenu(item) => {
@@ -89,6 +98,8 @@ impl MenuItemKind {
                     icon: state.icon.clone(),
                     #[cfg(target_os = "macos")]
                     styled_text: state.styled_text.clone(),
+                    #[cfg(target_os = "macos")]
+                    attributed_title: None,
                 }
             }
             MenuItemKind::Predefined(item) => {
@@ -101,6 +112,8 @@ impl MenuItemKind {
                     icon: None,
                     #[cfg(target_os = "macos")]
                     styled_text: None,
+                    #[cfg(target_os = "macos")]
+                    attributed_title: None,
                 }
             }
             MenuItemKind::Check(item) => {
@@ -113,6 +126,8 @@ impl MenuItemKind {
                     icon: None,
                     #[cfg(target_os = "macos")]
                     styled_text: state.styled_text.clone(),
+                    #[cfg(target_os = "macos")]
+                    attributed_title: None,
                 }
             }
             MenuItemKind::Icon(item) => {
@@ -125,6 +140,8 @@ impl MenuItemKind {
                     icon: state.icon.clone(),
                     #[cfg(target_os = "macos")]
                     styled_text: state.styled_text.clone(),
+                    #[cfg(target_os = "macos")]
+                    attributed_title: None,
                 }
             }
         }


### PR DESCRIPTION
## What

Adds a macOS-only `MenuItem::set_attributed_title(Option<&NSAttributedString>)` that sets a fully custom `NSAttributedString` as a menu item's label.

This complements the existing semantic `set_styled_text` / `TextStyle` API (#353). That API is intentionally semantic — the caller picks *meaning* (`Default`, `Secondary`) and each platform maps it to native conventions — which keeps labels correct across light/dark, increased contrast, and menu-font changes. Some real layouts, however, can't be expressed semantically:

- **Right-aligned trailing text.** The system battery menu right-aligns the percentage. AppKit does this with an `NSParagraphStyle` containing a right-aligned `NSTextTab` (tab stop) plus a `\t` between the left and right runs — a layout concern, not a per-run text style.
- **A custom foreground color** to tint a whole row (e.g. marking a "current"/"active" item by color instead of a checkmark), where the desired color isn't one of the semantic treatments.

Rather than grow the semantic enum with layout/color knobs, this PR adds a documented escape hatch: hand muda a ready-made `NSAttributedString` and it calls `-[NSMenuItem setAttributedTitle:]`. The doc comment is explicit that, because the caller supplies raw attributes, the caller owns legibility in light/dark, increased contrast, and font changes.

## How

- `MenuItemState` gains a macOS-only `attributed_title: Option<Retained<NSAttributedString>>`, stored in shared state so it survives native item re-creation (re-attach to a menu). It is threaded through `PlatformAttachArgs` and applied in `create_ns` after the `styled_text` step.
- `set_text` / `set_styled_text` clear it, so the "last setter wins" and the three labelling paths stay mutually exclusive.
- No new dependencies or features: muda already depends on `objc2`/`objc2-foundation` with the `NSAttributedString` feature. The API is `#[cfg(target_os = "macos")]`; other platforms are untouched.

## Example

```rust
use objc2_app_kit::{NSColor, NSFont, NSFontAttributeName,
    NSForegroundColorAttributeName, NSMutableParagraphStyle,
    NSParagraphStyleAttributeName, NSTextAlignment, NSTextTab};
use objc2_foundation::{NSMutableAttributedString, NSRange, NSString};

// "user@example.com\t42% / 88%" with the trailing part right-aligned at a tab stop,
// exactly like the OEM battery menu.
let s = NSMutableAttributedString::from_nsstring(
    &NSString::from_str("user@example.com\t42% / 88%"));
let para = NSMutableParagraphStyle::new();
let tab = unsafe { NSTextTab::initWithTextAlignment_location_options(
    NSTextTab::alloc(), NSTextAlignment::Right, 260.0, &Default::default()) };
para.setTabStops(&Default::default());
para.addTabStop(&tab);
// ... set attributes over the ranges, then:
menu_item.set_attributed_title(Some(&s));

// Clear back to plain text:
menu_item.set_attributed_title(None);
```

## Tradeoffs / notes

- Scoped to `MenuItem` (the only item kind with author-controlled label state); `Submenu`/`Check`/`Icon`/`Predefined` are unchanged.
- Tab-stop x must be chosen wider than the longest leading string (proportional font); the menu auto-sizes to content. These are inherent to the AppKit technique and are the caller's concern.
- Escape hatch by design: it does not try to keep custom colors adaptive — `set_styled_text` remains the recommended path when a semantic treatment fits.

Draft: opening for design feedback on whether an escape hatch like this is welcome alongside the semantic API, and on naming.
